### PR TITLE
Require `faraday-retry` gem for project

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     onlyoffice_github_helper (1.0.0)
+      faraday-retry (~> 2)
       octokit (>= 4, < 6)
 
 GEM
@@ -17,6 +18,8 @@ GEM
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.1)
+    faraday-retry (2.0.0)
+      faraday (~> 2.0)
     iniparse (1.5.0)
     json (2.6.2)
     octokit (5.6.1)

--- a/onlyoffice_github_helper.gemspec
+++ b/onlyoffice_github_helper.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   }
   s.files = Dir['lib/**/*']
   s.license = 'AGPL-3.0'
+  s.add_runtime_dependency('faraday-retry', '~> 2')
   s.add_runtime_dependency('octokit', '>= 4', '< 6')
   s.add_development_dependency('overcommit', '~> 0')
   s.add_development_dependency('rake', '~> 13')


### PR DESCRIPTION
This will remove annoying
```
To use retry middleware with Faraday v2.0+, install `faraday-retry` gem
```
message and allow to retry some actions by default

More details are here:
https://github.com/octokit/octokit.rb/discussions/1486